### PR TITLE
Implement users-stats CLI command in go-proxy

### DIFF
--- a/go-proxy/cmd/main.go
+++ b/go-proxy/cmd/main.go
@@ -27,7 +27,7 @@ func main() {
 	usersService := users.New(redisCli)
 
 	// Handle CLI commands, if passed
-	if handled := cli.HandleCLICommand(ctx, &cli.CLICommandsDeps{}); handled {
+	if handled := cli.HandleCLICommand(ctx, &cli.CLICommandsDeps{Redis: redisCli}); handled {
 		return
 	}
 

--- a/go-proxy/internal/cli/cli.go
+++ b/go-proxy/internal/cli/cli.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nskondratev/socks5-proxy-server/internal/cli/commands/stats"
 	"github.com/nskondratev/socks5-proxy-server/internal/config"
 	"github.com/nskondratev/socks5-proxy-server/internal/log"
 )
 
-type CLICommandsDeps struct{}
+type redis interface {
+	HGetAll(ctx context.Context, key string) (map[string]string, error)
+}
+
+type CLICommandsDeps struct {
+	Redis redis
+}
 
 type commandHandler interface {
 	CanHandle(ctx context.Context, commandName string) bool
@@ -28,7 +35,9 @@ func HandleCLICommand(ctx context.Context, deps *CLICommandsDeps) (handled bool)
 
 	fmt.Printf("In CLI command mode, process command with name: %s\n", commandName)
 
-	commands := []commandHandler{}
+	commands := []commandHandler{
+		stats.New(deps.Redis, os.Stdout),
+	}
 
 	for i := range commands {
 		if commands[i].CanHandle(ctx, commandName) {

--- a/go-proxy/internal/cli/commands/stats/command.go
+++ b/go-proxy/internal/cli/commands/stats/command.go
@@ -1,15 +1,36 @@
 package stats
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"text/tabwriter"
+)
 
-const command = "users-stats"
+const (
+	command      = "users-stats"
+	dataUsageKey = "user_usage_data"
+	authDateKey  = "user_auth_date"
+)
 
-type CommandHandler struct {
-	// TODO: add here needed dependencies
+type redis interface {
+	HGetAll(ctx context.Context, key string) (map[string]string, error)
 }
 
-func New() *CommandHandler {
-	return &CommandHandler{}
+type CommandHandler struct {
+	redis redis
+	out   io.Writer
+}
+
+func New(redis redis, out io.Writer) *CommandHandler {
+	if out == nil {
+		out = os.Stdout
+	}
+
+	return &CommandHandler{redis: redis, out: out}
 }
 
 func (h *CommandHandler) CanHandle(_ context.Context, commandName string) bool {
@@ -17,6 +38,81 @@ func (h *CommandHandler) CanHandle(_ context.Context, commandName string) bool {
 }
 
 func (h *CommandHandler) Handle(ctx context.Context) error {
-	// TODO: implement logic here
-	panic("not implemented")
+	if h.redis == nil {
+		return fmt.Errorf("[users-stats] redis dependency is not configured")
+	}
+
+	dataUsage, err := h.redis.HGetAll(ctx, dataUsageKey)
+	if err != nil {
+		return fmt.Errorf("[users-stats] failed to get usage stats: %w", err)
+	}
+
+	lastLogin, err := h.redis.HGetAll(ctx, authDateKey)
+	if err != nil {
+		return fmt.Errorf("[users-stats] failed to get last login stats: %w", err)
+	}
+
+	type userStat struct {
+		Username string
+		Usage    int64
+	}
+
+	stats := make([]userStat, 0, len(dataUsage))
+	for username, usageStr := range dataUsage {
+		usage, parseErr := strconv.ParseInt(usageStr, 10, 64)
+		if parseErr != nil {
+			return fmt.Errorf("[users-stats] failed to parse usage for user %s: %w", username, parseErr)
+		}
+
+		stats = append(stats, userStat{Username: username, Usage: usage})
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		return stats[i].Usage > stats[j].Usage
+	})
+
+	tw := tabwriter.NewWriter(h.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "#\tUsername\tData usage (in bytes)\tData usage (human readable)\tLast login")
+
+	for i, stat := range stats {
+		loginDate := lastLogin[stat.Username]
+		if loginDate == "" {
+			loginDate = "-"
+		}
+
+		fmt.Fprintf(
+			tw,
+			"%d\t%s\t%d\t%s\t%s\n",
+			i+1,
+			stat.Username,
+			stat.Usage,
+			formatBytes(stat.Usage),
+			loginDate,
+		)
+	}
+
+	if err = tw.Flush(); err != nil {
+		return fmt.Errorf("[users-stats] failed to print stats: %w", err)
+	}
+
+	return nil
+}
+
+func formatBytes(size int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+
+	switch {
+	case size > gb:
+		return fmt.Sprintf("%.2f GB", float64(size)/float64(gb))
+	case size > mb:
+		return fmt.Sprintf("%.2f MB", float64(size)/float64(mb))
+	case size > kb:
+		return fmt.Sprintf("%.2f KB", float64(size)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", size)
+	}
 }

--- a/go-proxy/internal/cli/commands/stats/command_test.go
+++ b/go-proxy/internal/cli/commands/stats/command_test.go
@@ -1,0 +1,96 @@
+package stats
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type redisMock struct {
+	data map[string]map[string]string
+	err  map[string]error
+}
+
+func (r *redisMock) HGetAll(_ context.Context, key string) (map[string]string, error) {
+	if err, ok := r.err[key]; ok {
+		return nil, err
+	}
+
+	return r.data[key], nil
+}
+
+func TestCommandHandler_Handle(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.NewBuffer(nil)
+	h := New(&redisMock{data: map[string]map[string]string{
+		dataUsageKey: {
+			"alice": "1025",
+			"bob":   "256",
+		},
+		authDateKey: {
+			"alice": "2026-01-01T10:00:00Z",
+		},
+	}}, buf)
+
+	err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "alice") || !strings.Contains(out, "bob") {
+		t.Fatalf("expected users to be printed, got %q", out)
+	}
+
+	if strings.Index(out, "alice") > strings.Index(out, "bob") {
+		t.Fatalf("expected alice to be listed before bob, got %q", out)
+	}
+
+	if !strings.Contains(out, "1.00 KB") {
+		t.Fatalf("expected human readable usage for alice, got %q", out)
+	}
+
+	if !strings.Contains(out, "-") {
+		t.Fatalf("expected missing last login fallback, got %q", out)
+	}
+}
+
+func TestCommandHandler_HandleRedisError(t *testing.T) {
+	t.Parallel()
+
+	h := New(&redisMock{err: map[string]error{dataUsageKey: errors.New("boom")}}, bytes.NewBuffer(nil))
+
+	err := h.Handle(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		size int64
+		want string
+	}{
+		{name: "bytes", size: 1024, want: "1024 B"},
+		{name: "kb", size: 1025, want: "1.00 KB"},
+		{name: "mb", size: 1048577, want: "1.00 MB"},
+		{name: "gb", size: 1073741825, want: "1.00 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := formatBytes(tt.size)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/go-proxy/internal/redis/redis.go
+++ b/go-proxy/internal/redis/redis.go
@@ -27,3 +27,7 @@ func (r *Redis) Close() error {
 func (r *Redis) HGet(ctx context.Context, key, field string) (string, error) {
 	return r.cli.HGet(ctx, key, field).Result()
 }
+
+func (r *Redis) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	return r.cli.HGetAll(ctx, key).Result()
+}


### PR DESCRIPTION
### Motivation

- Provide a Go implementation of the existing Node `users-stats` script so the `go-proxy` binary can show per-user data usage and last-login info from Redis.
- Reuse Redis keys `user_usage_data` and `user_auth_date` and present sorted, human-readable statistics in CLI mode.

### Description

- Added `internal/cli/commands/stats/command.go` implementing `users-stats` which reads `user_usage_data` and `user_auth_date` via Redis, sorts users by usage descending and prints a tabular view with human-readable sizes and a `-` fallback for missing last-login values.
- Introduced `formatBytes` helper to format bytes into `B/KB/MB/GB` strings and wrote the command to use `text/tabwriter` for output alignment.
- Wired the command into the CLI by registering `stats.New(deps.Redis, os.Stdout)` in `internal/cli/cli.go` and added a `Redis` dependency in `CLICommandsDeps` so the CLI can pass the Redis client.
- Extended the Redis wrapper (`internal/redis/redis.go`) with `HGetAll(ctx, key)` to support fetching all hash fields.
- Added unit tests `internal/cli/commands/stats/command_test.go` covering normal output ordering, Redis error handling, and `formatBytes` formatting.

### Testing

- Ran `cd go-proxy && go test ./...` and all tests in the module completed successfully.
- Added unit tests for the command which exercised output content and ordering, Redis error propagation, and byte-size formatting, and they passed under the `go test` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b44208f88326be0fdd96bb38c43c)