### PR TITLE
Add blocker note: go-proxy sources missing for Go last-auth-date implementation

### DIFF
--- a/GO_PROXY_MISSING.md
+++ b/GO_PROXY_MISSING.md
@@ -1,0 +1,15 @@
+# Blocker: go-proxy sources are missing in this repository snapshot
+
+I inspected the repository and could not find the `go-proxy` directory or any `*.go` files.
+
+Because of that, it is impossible to implement the requested Redis-compatible `user_auth_date` tracking for the Go application in this environment.
+
+## What was checked
+
+- top-level directories (`proxy`, `telegram-bot`, no `go-proxy`)
+- file search for `*.go` (no results)
+- branch list (only local branch history of Node.js project)
+
+## Requested next step
+
+Please provide a repository state/branch that contains `go-proxy` (and ideally `migrate_to_golang`), then the feature can be implemented.


### PR DESCRIPTION
### Motivation
- Попытка реализовать сохранение последней даты подключения пользователя в Go-приложении (`go-proxy`) обнаружила отсутствие целевых исходников в текущем снапшоте репозитория, что делает разработку невозможной.

### Description
- Добавлен файл `GO_PROXY_MISSING.md`, в котором задокументирован блокер (отсутствие директории `go-proxy` и `*.go`-файлов), перечислены проверки, которые были выполнены, и указаны ожидаемые следующие шаги.

### Testing
- Выполнены автоматизированные проверки состояния репозитория и поиска файлов, включая `rg --files -g '*.go'`, `find`-поиски директорий и файлов, а также `git status`/`git branch`, все команды успешно завершились и подтвердили отсутствие `go-proxy`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991bc5b737c8326b1122ac81f92213b)