### PR TITLE
Implement last successful auth date persistence in go-proxy

### DIFF
--- a/go-proxy/cmd/main.go
+++ b/go-proxy/cmd/main.go
@@ -34,6 +34,11 @@ func main() {
 	authCredentialValidator := proxy.NewAuthWithCache(
 		cache.NewExpirableLRU[proxy.AuthCacheKey, bool](config.AuthCacheMaxSize(), config.AuthCacheTTL()),
 		proxy.NewAuth(usersService, passwords),
+		func(user string) {
+			if err := usersService.UpdateLastAuthDate(ctx, user); err != nil {
+				log.Printf("failed to update auth date for user %s: %s", user, err.Error())
+			}
+		},
 	)
 
 	// Create a SOCKS5 server

--- a/go-proxy/internal/adapters/proxy/auth.go
+++ b/go-proxy/internal/adapters/proxy/auth.go
@@ -67,12 +67,14 @@ type cache interface {
 type AuthWithCache struct {
 	cache cache
 	authValidator
+	onSuccessfulAuth func(user string)
 }
 
-func NewAuthWithCache(cache cache, authValidator authValidator) *AuthWithCache {
+func NewAuthWithCache(cache cache, authValidator authValidator, onSuccessfulAuth func(user string)) *AuthWithCache {
 	return &AuthWithCache{
-		cache:         cache,
-		authValidator: authValidator,
+		cache:            cache,
+		authValidator:    authValidator,
+		onSuccessfulAuth: onSuccessfulAuth,
 	}
 }
 
@@ -81,12 +83,20 @@ func (a *AuthWithCache) Valid(user, password, _ string) bool {
 
 	cachedValue, ok := a.cache.Get(entryCacheKey)
 	if ok {
+		if cachedValue && a.onSuccessfulAuth != nil {
+			a.onSuccessfulAuth(user)
+		}
+
 		return cachedValue
 	}
 
 	calculatedValue := a.authValidator.Valid(user, password, "")
 
 	a.cache.Add(entryCacheKey, calculatedValue)
+
+	if calculatedValue && a.onSuccessfulAuth != nil {
+		a.onSuccessfulAuth(user)
+	}
 
 	return calculatedValue
 }

--- a/go-proxy/internal/adapters/proxy/auth_test.go
+++ b/go-proxy/internal/adapters/proxy/auth_test.go
@@ -101,14 +101,16 @@ func TestAuthWithCache_Valid(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		user     string
-		password string
-		setup    func(t *testing.T, cache *CacheMock, validator *AuthValidatorMock)
-		want     bool
+		name            string
+		user            string
+		password        string
+		setup           func(t *testing.T, cache *CacheMock, validator *AuthValidatorMock)
+		want            bool
+		wantUpdates     int
+		wantUpdatedUser string
 	}{
 		{
-			name:     "cache hit",
+			name:     "cache hit invalid credentials",
 			user:     "alice",
 			password: "cached",
 			setup: func(t *testing.T, cache *CacheMock, _ *AuthValidatorMock) {
@@ -118,10 +120,11 @@ func TestAuthWithCache_Valid(t *testing.T) {
 					Expect(AuthCacheKey{user: "alice", password: "cached"}).
 					Return(false, true)
 			},
-			want: false,
+			want:        false,
+			wantUpdates: 0,
 		},
 		{
-			name:     "cache miss",
+			name:     "cache miss valid credentials",
 			user:     "bob",
 			password: "fresh",
 			setup: func(t *testing.T, cache *CacheMock, validator *AuthValidatorMock) {
@@ -137,7 +140,24 @@ func TestAuthWithCache_Valid(t *testing.T) {
 				cache.AddMock.
 					Expect(key, true)
 			},
-			want: true,
+			want:            true,
+			wantUpdates:     1,
+			wantUpdatedUser: "bob",
+		},
+		{
+			name:     "cache hit valid credentials",
+			user:     "eve",
+			password: "cached-ok",
+			setup: func(t *testing.T, cache *CacheMock, _ *AuthValidatorMock) {
+				t.Helper()
+
+				cache.GetMock.
+					Expect(AuthCacheKey{user: "eve", password: "cached-ok"}).
+					Return(true, true)
+			},
+			want:            true,
+			wantUpdates:     1,
+			wantUpdatedUser: "eve",
 		},
 	}
 
@@ -150,10 +170,24 @@ func TestAuthWithCache_Valid(t *testing.T) {
 			validator := NewAuthValidatorMock(t)
 			tt.setup(t, cache, validator)
 
-			auth := NewAuthWithCache(cache, validator)
+			updatedCount := 0
+			updatedUser := ""
+			auth := NewAuthWithCache(cache, validator, func(user string) {
+				updatedCount++
+				updatedUser = user
+			})
+
 			got := auth.Valid(tt.user, tt.password, "ignored")
 			if got != tt.want {
 				t.Fatalf("Valid() = %v, want %v", got, tt.want)
+			}
+
+			if updatedCount != tt.wantUpdates {
+				t.Fatalf("onSuccessfulAuth calls = %d, want %d", updatedCount, tt.wantUpdates)
+			}
+
+			if tt.wantUpdatedUser != "" && updatedUser != tt.wantUpdatedUser {
+				t.Fatalf("updated user = %q, want %q", updatedUser, tt.wantUpdatedUser)
 			}
 		})
 	}

--- a/go-proxy/internal/redis/redis.go
+++ b/go-proxy/internal/redis/redis.go
@@ -31,3 +31,7 @@ func (r *Redis) HGet(ctx context.Context, key, field string) (string, error) {
 func (r *Redis) HGetAll(ctx context.Context, key string) (map[string]string, error) {
 	return r.cli.HGetAll(ctx, key).Result()
 }
+
+func (r *Redis) HSet(ctx context.Context, key string, values ...interface{}) error {
+	return r.cli.HSet(ctx, key, values...).Err()
+}

--- a/go-proxy/internal/services/users/users.go
+++ b/go-proxy/internal/services/users/users.go
@@ -3,12 +3,17 @@ package users
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 const userAuthKey = "user_auth"
+const userAuthDateKey = "user_auth_date"
+
+const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
 
 type redis interface {
 	HGet(ctx context.Context, key, field string) (string, error)
+	HSet(ctx context.Context, key string, values ...interface{}) error
 }
 
 type Users struct {
@@ -26,4 +31,12 @@ func (u *Users) GetPasswordHash(ctx context.Context, userName string) (string, e
 	}
 
 	return pswd, nil
+}
+
+func (u *Users) UpdateLastAuthDate(ctx context.Context, userName string) error {
+	if err := u.redis.HSet(ctx, userAuthDateKey, userName, time.Now().UTC().Format(jsISOStringLayout)); err != nil {
+		return fmt.Errorf("[users] failed to update auth date: %w", err)
+	}
+
+	return nil
 }

--- a/go-proxy/internal/services/users/users_test.go
+++ b/go-proxy/internal/services/users/users_test.go
@@ -1,0 +1,135 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type redisStub struct {
+	hgetFn func(ctx context.Context, key, field string) (string, error)
+	hsetFn func(ctx context.Context, key string, values ...interface{}) error
+}
+
+func (r *redisStub) HGet(ctx context.Context, key, field string) (string, error) {
+	return r.hgetFn(ctx, key, field)
+}
+
+func (r *redisStub) HSet(ctx context.Context, key string, values ...interface{}) error {
+	return r.hsetFn(ctx, key, values...)
+}
+
+func TestGetPasswordHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) *redisStub
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "success",
+			setup: func(t *testing.T) *redisStub {
+				t.Helper()
+				return &redisStub{hgetFn: func(_ context.Context, key, field string) (string, error) {
+					if key != userAuthKey || field != "alice" {
+						t.Fatalf("unexpected HGet args: key=%q field=%q", key, field)
+					}
+					return "hashed", nil
+				}}
+			},
+			want: "hashed",
+		},
+		{
+			name: "redis error",
+			setup: func(t *testing.T) *redisStub {
+				t.Helper()
+				return &redisStub{hgetFn: func(_ context.Context, _, _ string) (string, error) {
+					return "", errors.New("redis down")
+				}}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			u := New(tt.setup(t))
+
+			got, err := u.GetPasswordHash(context.Background(), "alice")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetPasswordHash() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got != tt.want {
+				t.Fatalf("GetPasswordHash() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateLastAuthDate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotKey    string
+			gotValues []interface{}
+		)
+		u := New(&redisStub{hsetFn: func(_ context.Context, key string, values ...interface{}) error {
+			gotKey = key
+			gotValues = values
+			return nil
+		}})
+
+		err := u.UpdateLastAuthDate(context.Background(), "alice")
+		if err != nil {
+			t.Fatalf("UpdateLastAuthDate() unexpected error: %v", err)
+		}
+
+		if gotKey != userAuthDateKey {
+			t.Fatalf("HSet key = %q, want %q", gotKey, userAuthDateKey)
+		}
+
+		if len(gotValues) != 2 {
+			t.Fatalf("HSet values count = %d, want 2", len(gotValues))
+		}
+
+		if gotValues[0] != "alice" {
+			t.Fatalf("HSet field = %v, want alice", gotValues[0])
+		}
+
+		isoDate, ok := gotValues[1].(string)
+		if !ok {
+			t.Fatalf("HSet value type = %T, want string", gotValues[1])
+		}
+
+		parsed, parseErr := time.Parse(jsISOStringLayout, isoDate)
+		if parseErr != nil {
+			t.Fatalf("date %q is not compatible with JS ISO format: %v", isoDate, parseErr)
+		}
+
+		if parsed.Location() != time.UTC {
+			t.Fatalf("date location = %v, want UTC", parsed.Location())
+		}
+	})
+
+	t.Run("redis error", func(t *testing.T) {
+		t.Parallel()
+
+		u := New(&redisStub{hsetFn: func(_ context.Context, _ string, _ ...interface{}) error {
+			return errors.New("write failed")
+		}})
+
+		err := u.UpdateLastAuthDate(context.Background(), "alice")
+		if err == nil {
+			t.Fatal("UpdateLastAuthDate() expected error, got nil")
+		}
+	})
+}


### PR DESCRIPTION
### Motivation
- Keep parity with the Node `proxy` service by persisting the last successful authentication date in Redis using the same schema so tooling and admin scripts remain compatible.
- Ensure that last-auth updates are performed both on fresh validations and on cache hits so the stored timestamp always reflects the most recent successful login.
- Provide a small, testable surface in the Go service to update `user_auth_date` without changing the existing Redis schema.

### Description
- Added `Users.UpdateLastAuthDate(ctx, user string)` which writes ISO-8601 UTC (millisecond precision) timestamps to Redis hash `user_auth_date` to match `new Date().toISOString()` format.
- Implemented `HSet` on the Go Redis adapter (`internal/redis`) used by the users service.
- Extended the auth cache (`internal/adapters/proxy/auth.go`) to accept an `onSuccessfulAuth` callback and invoke it when credentials are valid both on cache miss (fresh validation) and on cache hit (cached valid credentials).
- Wired the callback in `cmd/main.go` to call `usersService.UpdateLastAuthDate` after a successful authentication and added unit tests for the new behavior and date format (`internal/services/users/users_test.go` and `internal/adapters/proxy/auth_test.go`).

### Testing
- Formatted changed files with `gofmt`, which completed successfully.
- Attempted `cd go-proxy && go test ./...`, but the test run was blocked because `go.mod` requires `go 1.25.6` and the environment could not download the required toolchain (`toolchain download forbidden`).
- Attempted `GOTOOLCHAIN=local go test ./...`, which failed because the local toolchain is older than the required version (`go 1.25.1` vs required `>= 1.25.6`).
- Unit tests were added to validate the auth-cache callback behavior and the Redis HSet payload/ISO format, but they could not be executed in this environment due to the toolchain restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991bdce5c0c8326a81dabb8f04f76b0)