### PR TITLE
Implement create-user and delete-user CLI commands in go-proxy

### DIFF
--- a/go-proxy/internal/cli/cli.go
+++ b/go-proxy/internal/cli/cli.go
@@ -5,13 +5,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nskondratev/socks5-proxy-server/internal/cli/commands/createuser"
+	"github.com/nskondratev/socks5-proxy-server/internal/cli/commands/deleteuser"
 	"github.com/nskondratev/socks5-proxy-server/internal/cli/commands/stats"
 	"github.com/nskondratev/socks5-proxy-server/internal/config"
 	"github.com/nskondratev/socks5-proxy-server/internal/log"
 )
 
 type redis interface {
+	HGet(ctx context.Context, key, field string) (string, error)
 	HGetAll(ctx context.Context, key string) (map[string]string, error)
+	HSet(ctx context.Context, key string, values ...interface{}) error
+	HDel(ctx context.Context, key string, fields ...string) error
 }
 
 type CLICommandsDeps struct {
@@ -36,6 +41,8 @@ func HandleCLICommand(ctx context.Context, deps *CLICommandsDeps) (handled bool)
 	fmt.Printf("In CLI command mode, process command with name: %s\n", commandName)
 
 	commands := []commandHandler{
+		createuser.New(deps.Redis, os.Stdin, os.Stdout),
+		deleteuser.New(deps.Redis, os.Stdin, os.Stdout),
 		stats.New(deps.Redis, os.Stdout),
 	}
 
@@ -46,6 +53,8 @@ func HandleCLICommand(ctx context.Context, deps *CLICommandsDeps) (handled bool)
 
 				return handled
 			}
+
+			return handled
 		}
 	}
 

--- a/go-proxy/internal/cli/commands/createuser/command.go
+++ b/go-proxy/internal/cli/commands/createuser/command.go
@@ -1,0 +1,91 @@
+package createuser
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	goredis "github.com/redis/go-redis/v9"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	command     = "create-user"
+	userAuthKey = "user_auth"
+)
+
+type redis interface {
+	HGet(ctx context.Context, key, field string) (string, error)
+	HSet(ctx context.Context, key string, values ...interface{}) error
+}
+
+type CommandHandler struct {
+	redis redis
+	in    *bufio.Reader
+	out   io.Writer
+}
+
+func New(redis redis, in io.Reader, out io.Writer) *CommandHandler {
+	if in == nil {
+		in = os.Stdin
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+
+	return &CommandHandler{redis: redis, in: bufio.NewReader(in), out: out}
+}
+
+func (h *CommandHandler) CanHandle(_ context.Context, commandName string) bool {
+	return commandName == command
+}
+
+func (h *CommandHandler) Handle(ctx context.Context) error {
+	if h.redis == nil {
+		return fmt.Errorf("[create-user] redis dependency is not configured")
+	}
+
+	fmt.Fprint(h.out, "Input username and press Enter: ")
+	username, err := h.readInputLine()
+	if err != nil {
+		return fmt.Errorf("[create-user] failed to read username: %w", err)
+	}
+
+	fmt.Fprint(h.out, "Input password and press Enter to create new user: ")
+	password, err := h.readInputLine()
+	if err != nil {
+		return fmt.Errorf("[create-user] failed to read password: %w", err)
+	}
+
+	if _, err = h.redis.HGet(ctx, userAuthKey, username); err == nil {
+		return fmt.Errorf("[create-user] user with provided username already exists")
+	} else if !errors.Is(err, goredis.Nil) {
+		return fmt.Errorf("[create-user] failed to check if user exists: %w", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("[create-user] failed to hash password: %w", err)
+	}
+
+	if err = h.redis.HSet(ctx, userAuthKey, username, string(hash)); err != nil {
+		return fmt.Errorf("[create-user] failed to create user: %w", err)
+	}
+
+	fmt.Fprintln(h.out, "User successfully created.")
+
+	return nil
+}
+
+func (h *CommandHandler) readInputLine() (string, error) {
+	line, err := h.in.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+
+	return strings.TrimSpace(line), nil
+}

--- a/go-proxy/internal/cli/commands/createuser/command_test.go
+++ b/go-proxy/internal/cli/commands/createuser/command_test.go
@@ -1,0 +1,91 @@
+package createuser
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type redisMock struct {
+	hGetValue string
+	hGetErr   error
+	hSetErr   error
+	hSetKey   string
+	hSetData  []interface{}
+}
+
+func (m *redisMock) HGet(_ context.Context, _, _ string) (string, error) {
+	return m.hGetValue, m.hGetErr
+}
+
+func (m *redisMock) HSet(_ context.Context, key string, values ...interface{}) error {
+	m.hSetKey = key
+	m.hSetData = values
+
+	return m.hSetErr
+}
+
+func TestCommandHandler_Handle(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.NewBuffer(nil)
+	redis := &redisMock{hGetErr: goredis.Nil}
+	h := New(redis, strings.NewReader("alice\nsecret\n"), buf)
+
+	err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if redis.hSetKey != userAuthKey {
+		t.Fatalf("expected key %q, got %q", userAuthKey, redis.hSetKey)
+	}
+
+	if len(redis.hSetData) != 2 {
+		t.Fatalf("expected two hset args, got %d", len(redis.hSetData))
+	}
+
+	if redis.hSetData[0] != "alice" {
+		t.Fatalf("expected username alice, got %v", redis.hSetData[0])
+	}
+
+	hashValue, ok := redis.hSetData[1].(string)
+	if !ok {
+		t.Fatalf("expected hash to be string, got %T", redis.hSetData[1])
+	}
+
+	if err = bcrypt.CompareHashAndPassword([]byte(hashValue), []byte("secret")); err != nil {
+		t.Fatalf("expected password to be hashed, compare failed: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "User successfully created.") {
+		t.Fatalf("expected success output, got %q", buf.String())
+	}
+}
+
+func TestCommandHandler_HandleUserExists(t *testing.T) {
+	t.Parallel()
+
+	h := New(&redisMock{hGetValue: "already-hashed"}, strings.NewReader("alice\nsecret\n"), bytes.NewBuffer(nil))
+
+	err := h.Handle(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCommandHandler_HandleHGetError(t *testing.T) {
+	t.Parallel()
+
+	h := New(&redisMock{hGetErr: errors.New("boom")}, strings.NewReader("alice\nsecret\n"), bytes.NewBuffer(nil))
+
+	err := h.Handle(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/go-proxy/internal/cli/commands/deleteuser/command.go
+++ b/go-proxy/internal/cli/commands/deleteuser/command.go
@@ -1,0 +1,79 @@
+package deleteuser
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const (
+	command     = "delete-user"
+	userAuthKey = "user_auth"
+)
+
+type redis interface {
+	HGet(ctx context.Context, key, field string) (string, error)
+	HDel(ctx context.Context, key string, fields ...string) error
+}
+
+type CommandHandler struct {
+	redis redis
+	in    *bufio.Reader
+	out   io.Writer
+}
+
+func New(redis redis, in io.Reader, out io.Writer) *CommandHandler {
+	if in == nil {
+		in = os.Stdin
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+
+	return &CommandHandler{redis: redis, in: bufio.NewReader(in), out: out}
+}
+
+func (h *CommandHandler) CanHandle(_ context.Context, commandName string) bool {
+	return commandName == command
+}
+
+func (h *CommandHandler) Handle(ctx context.Context) error {
+	if h.redis == nil {
+		return fmt.Errorf("[delete-user] redis dependency is not configured")
+	}
+
+	fmt.Fprint(h.out, "Input username and press Enter: ")
+	username, err := h.readInputLine()
+	if err != nil {
+		return fmt.Errorf("[delete-user] failed to read username: %w", err)
+	}
+
+	if _, err = h.redis.HGet(ctx, userAuthKey, username); errors.Is(err, goredis.Nil) {
+		return fmt.Errorf("[delete-user] user with provided username not found")
+	} else if err != nil {
+		return fmt.Errorf("[delete-user] failed to check if user exists: %w", err)
+	}
+
+	if err = h.redis.HDel(ctx, userAuthKey, username); err != nil {
+		return fmt.Errorf("[delete-user] failed to delete user: %w", err)
+	}
+
+	fmt.Fprintln(h.out, "User successfully deleted.")
+
+	return nil
+}
+
+func (h *CommandHandler) readInputLine() (string, error) {
+	line, err := h.in.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+
+	return strings.TrimSpace(line), nil
+}

--- a/go-proxy/internal/cli/commands/deleteuser/command_test.go
+++ b/go-proxy/internal/cli/commands/deleteuser/command_test.go
@@ -1,0 +1,76 @@
+package deleteuser
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+type redisMock struct {
+	hGetErr  error
+	hDelErr  error
+	hDelKey  string
+	hDelArgs []string
+}
+
+func (m *redisMock) HGet(_ context.Context, _, _ string) (string, error) {
+	return "hashed-password", m.hGetErr
+}
+
+func (m *redisMock) HDel(_ context.Context, key string, fields ...string) error {
+	m.hDelKey = key
+	m.hDelArgs = fields
+
+	return m.hDelErr
+}
+
+func TestCommandHandler_Handle(t *testing.T) {
+	t.Parallel()
+
+	buf := bytes.NewBuffer(nil)
+	redis := &redisMock{}
+	h := New(redis, strings.NewReader("alice\n"), buf)
+
+	err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if redis.hDelKey != userAuthKey {
+		t.Fatalf("expected key %q, got %q", userAuthKey, redis.hDelKey)
+	}
+
+	if len(redis.hDelArgs) != 1 || redis.hDelArgs[0] != "alice" {
+		t.Fatalf("expected username alice, got %v", redis.hDelArgs)
+	}
+
+	if !strings.Contains(buf.String(), "User successfully deleted.") {
+		t.Fatalf("expected success output, got %q", buf.String())
+	}
+}
+
+func TestCommandHandler_HandleNotFound(t *testing.T) {
+	t.Parallel()
+
+	h := New(&redisMock{hGetErr: goredis.Nil}, strings.NewReader("alice\n"), bytes.NewBuffer(nil))
+
+	err := h.Handle(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCommandHandler_HandleHDelError(t *testing.T) {
+	t.Parallel()
+
+	h := New(&redisMock{hDelErr: errors.New("boom")}, strings.NewReader("alice\n"), bytes.NewBuffer(nil))
+
+	err := h.Handle(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/go-proxy/internal/redis/redis.go
+++ b/go-proxy/internal/redis/redis.go
@@ -35,3 +35,7 @@ func (r *Redis) HGetAll(ctx context.Context, key string) (map[string]string, err
 func (r *Redis) HSet(ctx context.Context, key string, values ...interface{}) error {
 	return r.cli.HSet(ctx, key, values...).Err()
 }
+
+func (r *Redis) HDel(ctx context.Context, key string, fields ...string) error {
+	return r.cli.HDel(ctx, key, fields...).Err()
+}


### PR DESCRIPTION
### Motivation
- Provide Go-native CLI parity with existing Node.js scripts for user management so `go-proxy` can create and delete Redis-backed users without relying on the `proxy` service.
- Allow administrators to manage `user_auth` entries (create with bcrypt-hashed password and delete) directly from the `go-proxy` binary.

### Description
- Added `create-user` CLI handler under `internal/cli/commands/createuser` that prompts for username/password, verifies non-existence in Redis (`user_auth`), bcrypt-hashes the password, and stores the hash with `HSet`.
- Added `delete-user` CLI handler under `internal/cli/commands/deleteuser` that prompts for username, verifies existence, and deletes the user from Redis using `HDel`.
- Wired both handlers into the CLI dispatcher in `internal/cli/cli.go` and updated the dispatcher to return immediately after a successful command to avoid printing `Unknown command`.
- Extended the Redis adapter `internal/redis/redis.go` with an `HDel` method and added unit tests for both handlers mirroring the Node.js behavior and error cases.

### Testing
- Ran `gofmt` on the changed files to ensure formatting was applied successfully.
- Added unit tests for `create-user` and `delete-user` handlers (`command_test.go` files were included) but `go test ./...` could not be executed in this environment because `go.mod` requires `go 1.25.6` while the local toolchain is `go1.25.1` and automatic toolchain download was blocked, so tests were not run here.
- Verified locally in tests that password hashing uses `bcrypt` by comparing hashes in the newly added unit tests (tests present but not executed due to the Go toolchain constraint).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c41a2ed083268b2a0e564482a02b)