### PR TITLE
go-proxy: move traffic accounting to dial-level usage-tracked connection

### DIFF
--- a/go-proxy/cmd/main.go
+++ b/go-proxy/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"io"
 	"log"
+	"net"
 	"os"
 
 	"github.com/things-go/go-socks5"
@@ -41,13 +41,27 @@ func main() {
 		},
 	)
 
+	dialer := &net.Dialer{}
+
 	// Create a SOCKS5 server
 	server := socks5.NewServer(
 		socks5.WithLogger(socks5.NewLogger(log.New(os.Stdout, "socks5: ", log.LstdFlags))),
-		socks5.WithConnectMiddleware(func(ctx context.Context, writer io.Writer, request *socks5.Request) error {
-			log.Println("new connection")
+		socks5.WithDialAndRequest(func(ctx context.Context, network, addr string, request *socks5.Request) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
 
-			return nil
+			username, ok := getUsernameFromRequest(request)
+			if !ok {
+				return conn, nil
+			}
+
+			return proxy.NewUsageTrackedConn(conn, func(dataLen int64) {
+				if err := usersService.IncreaseDataUsage(ctx, username, dataLen); err != nil {
+					log.Printf("failed to increase data usage for user %s: %s", username, err.Error())
+				}
+			}), nil
 		}),
 		socks5.WithCredential(authCredentialValidator),
 	)
@@ -56,4 +70,21 @@ func main() {
 	if err := server.ListenAndServe("tcp", ":8000"); err != nil {
 		panic(err)
 	}
+}
+
+func getUsernameFromRequest(request *socks5.Request) (string, bool) {
+	if request == nil || request.AuthContext == nil || request.AuthContext.Payload == nil {
+		return "", false
+	}
+
+	username, ok := request.AuthContext.Payload["Username"]
+	if !ok || username == "" {
+		username = request.AuthContext.Payload["username"]
+	}
+
+	if username == "" {
+		return "", false
+	}
+
+	return username, true
 }

--- a/go-proxy/internal/adapters/proxy/usage_conn.go
+++ b/go-proxy/internal/adapters/proxy/usage_conn.go
@@ -1,0 +1,30 @@
+package proxy
+
+import "net"
+
+type usageTrackedConn struct {
+	net.Conn
+	onData func(dataLen int64)
+}
+
+func NewUsageTrackedConn(conn net.Conn, onData func(dataLen int64)) net.Conn {
+	return &usageTrackedConn{Conn: conn, onData: onData}
+}
+
+func (c *usageTrackedConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 && c.onData != nil {
+		c.onData(int64(n))
+	}
+
+	return n, err
+}
+
+func (c *usageTrackedConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n > 0 && c.onData != nil {
+		c.onData(int64(n))
+	}
+
+	return n, err
+}

--- a/go-proxy/internal/adapters/proxy/usage_conn_test.go
+++ b/go-proxy/internal/adapters/proxy/usage_conn_test.go
@@ -1,0 +1,76 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestUsageTrackedConn_Read(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	const expected = int64(5)
+	called := int64(0)
+	conn := NewUsageTrackedConn(client, func(dataLen int64) {
+		called += dataLen
+	})
+
+	go func() {
+		_, _ = server.Write([]byte("hello"))
+	}()
+
+	buf := make([]byte, 5)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("Read() unexpected error: %v", err)
+	}
+
+	if n != int(expected) {
+		t.Fatalf("Read() bytes = %d, want %d", n, expected)
+	}
+
+	if called != expected {
+		t.Fatalf("onData called with %d bytes, want %d", called, expected)
+	}
+}
+
+func TestUsageTrackedConn_Write(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	const expected = int64(4)
+	called := int64(0)
+	conn := NewUsageTrackedConn(client, func(dataLen int64) {
+		called += dataLen
+	})
+
+	go func() {
+		_ = server.SetReadDeadline(time.Now().Add(time.Second))
+		_, _ = io.ReadFull(server, make([]byte, expected))
+	}()
+
+	n, err := conn.Write([]byte("ping"))
+	if err != nil {
+		t.Fatalf("Write() unexpected error: %v", err)
+	}
+
+	if n != int(expected) {
+		t.Fatalf("Write() bytes = %d, want %d", n, expected)
+	}
+
+	if called != expected {
+		t.Fatalf("onData called with %d bytes, want %d", called, expected)
+	}
+}

--- a/go-proxy/internal/redis/redis.go
+++ b/go-proxy/internal/redis/redis.go
@@ -39,3 +39,7 @@ func (r *Redis) HSet(ctx context.Context, key string, values ...interface{}) err
 func (r *Redis) HDel(ctx context.Context, key string, fields ...string) error {
 	return r.cli.HDel(ctx, key, fields...).Err()
 }
+
+func (r *Redis) HIncrBy(ctx context.Context, key, field string, incr int64) error {
+	return r.cli.HIncrBy(ctx, key, field, incr).Err()
+}

--- a/go-proxy/internal/services/users/users.go
+++ b/go-proxy/internal/services/users/users.go
@@ -8,12 +8,14 @@ import (
 
 const userAuthKey = "user_auth"
 const userAuthDateKey = "user_auth_date"
+const userUsageDataKey = "user_usage_data"
 
 const jsISOStringLayout = "2006-01-02T15:04:05.000Z"
 
 type redis interface {
 	HGet(ctx context.Context, key, field string) (string, error)
 	HSet(ctx context.Context, key string, values ...interface{}) error
+	HIncrBy(ctx context.Context, key, field string, incr int64) error
 }
 
 type Users struct {
@@ -36,6 +38,14 @@ func (u *Users) GetPasswordHash(ctx context.Context, userName string) (string, e
 func (u *Users) UpdateLastAuthDate(ctx context.Context, userName string) error {
 	if err := u.redis.HSet(ctx, userAuthDateKey, userName, time.Now().UTC().Format(jsISOStringLayout)); err != nil {
 		return fmt.Errorf("[users] failed to update auth date: %w", err)
+	}
+
+	return nil
+}
+
+func (u *Users) IncreaseDataUsage(ctx context.Context, userName string, dataLen int64) error {
+	if err := u.redis.HIncrBy(ctx, userUsageDataKey, userName, dataLen); err != nil {
+		return fmt.Errorf("[users] failed to increase data usage: %w", err)
 	}
 
 	return nil

--- a/go-proxy/internal/services/users/users_test.go
+++ b/go-proxy/internal/services/users/users_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 type redisStub struct {
-	hgetFn func(ctx context.Context, key, field string) (string, error)
-	hsetFn func(ctx context.Context, key string, values ...interface{}) error
+	hgetFn    func(ctx context.Context, key, field string) (string, error)
+	hsetFn    func(ctx context.Context, key string, values ...interface{}) error
+	hincrByFn func(ctx context.Context, key, field string, incr int64) error
 }
 
 func (r *redisStub) HGet(ctx context.Context, key, field string) (string, error) {
@@ -18,6 +19,10 @@ func (r *redisStub) HGet(ctx context.Context, key, field string) (string, error)
 
 func (r *redisStub) HSet(ctx context.Context, key string, values ...interface{}) error {
 	return r.hsetFn(ctx, key, values...)
+}
+
+func (r *redisStub) HIncrBy(ctx context.Context, key, field string, incr int64) error {
+	return r.hincrByFn(ctx, key, field, incr)
 }
 
 func TestGetPasswordHash(t *testing.T) {
@@ -130,6 +135,57 @@ func TestUpdateLastAuthDate(t *testing.T) {
 		err := u.UpdateLastAuthDate(context.Background(), "alice")
 		if err == nil {
 			t.Fatal("UpdateLastAuthDate() expected error, got nil")
+		}
+	})
+}
+
+func TestIncreaseDataUsage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotKey   string
+			gotField string
+			gotIncr  int64
+		)
+
+		u := New(&redisStub{hincrByFn: func(_ context.Context, key, field string, incr int64) error {
+			gotKey = key
+			gotField = field
+			gotIncr = incr
+			return nil
+		}})
+
+		err := u.IncreaseDataUsage(context.Background(), "alice", 512)
+		if err != nil {
+			t.Fatalf("IncreaseDataUsage() unexpected error: %v", err)
+		}
+
+		if gotKey != userUsageDataKey {
+			t.Fatalf("HIncrBy key = %q, want %q", gotKey, userUsageDataKey)
+		}
+
+		if gotField != "alice" {
+			t.Fatalf("HIncrBy field = %q, want alice", gotField)
+		}
+
+		if gotIncr != 512 {
+			t.Fatalf("HIncrBy incr = %d, want 512", gotIncr)
+		}
+	})
+
+	t.Run("redis error", func(t *testing.T) {
+		t.Parallel()
+
+		u := New(&redisStub{hincrByFn: func(_ context.Context, _, _ string, _ int64) error {
+			return errors.New("write failed")
+		}})
+
+		err := u.IncreaseDataUsage(context.Background(), "alice", 512)
+		if err == nil {
+			t.Fatal("IncreaseDataUsage() expected error, got nil")
 		}
 	})
 }


### PR DESCRIPTION
### Motivation
- Accounting per proxied data chunk belongs at the transport I/O layer (matching Node.js `proxyData` semantics) rather than in `ConnectMiddleware` which runs only at connection setup.
- The previous reflection-based parsing of `socks5.Request` fields was brittle and unnecessary once accounting is performed on actual reads/writes.

### Description
- Replaced connection-time accounting with a dial-level wrapper by using `socks5.WithDialAndRequest` in `cmd/main.go` and wrapping outbound connections with `proxy.NewUsageTrackedConn` to report per-chunk byte counts.
- Added `internal/adapters/proxy/usage_conn.go`, a `net.Conn` wrapper that invokes a callback on every successful `Read` and `Write` with the number of bytes transferred, and simplified username extraction via `getUsernameFromRequest`.
- Added `Users.IncreaseDataUsage` which updates Redis using a new `HIncrBy` Redis method, and implemented `HIncrBy` in the Redis adapter to support atomic increments.
- Added unit tests for the connection wrapper (`internal/adapters/proxy/usage_conn_test.go`) and for `IncreaseDataUsage` (`internal/services/users/users_test.go`) to validate behavior.

### Testing
- Ran `gofmt` on modified files (`cmd/main.go`, new files under `internal/adapters/proxy`) successfully.
- Attempted `go test ./...` in `go-proxy`, but tests could not run in this environment because `go.mod` requires `go >= 1.25.6` while the available toolchain is `go 1.25.1`, so the test run failed due to toolchain mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f90a4ee08326aa193a3c1c0ae3a2)