### PR TITLE
[codex] fix loadtest local sink target resolution

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -46,6 +46,8 @@ go run ./cmd/loadtest \
     --password=test1
 ```
 
+When `--use-local-sink=true`, the load test rewrites `host.docker.internal`, `localhost`, and other loopback-style target hosts to the current machine's non-loopback IPv4 address before sending the SOCKS5 `CONNECT` request. This keeps the built-in sink reachable when the proxy itself runs inside Docker.
+
 ### What the load test measures
 
 - Number of simultaneous connections (`max_simultaneous_connections`)

--- a/proxy/cmd/loadtest/main.go
+++ b/proxy/cmd/loadtest/main.go
@@ -85,26 +85,37 @@ type report struct {
 }
 
 func main() {
+	if err := run(); err != nil {
+		exitErr(err)
+	}
+}
+
+func run() error {
 	cfg, err := parseFlags()
 	if err != nil {
-		exitErr(err)
+		return err
+	}
+
+	cfg, err = normalizeLocalSinkTarget(cfg)
+	if err != nil {
+		return err
 	}
 
 	if cfg.UseLocalSink {
 		sinkAddr, err := sinkListenAddr(cfg.TargetAddr)
 		if err != nil {
-			exitErr(fmt.Errorf("failed to resolve local sink bind address from target %q: %w", cfg.TargetAddr, err))
+			return fmt.Errorf("failed to resolve local sink bind address from target %q: %w", cfg.TargetAddr, err)
 		}
 
 		stopSink, err := runLocalSink(sinkAddr)
 		if err != nil {
-			exitErr(fmt.Errorf("failed to run local sink server on %s: %w", sinkAddr, err))
+			return fmt.Errorf("failed to run local sink server on %s: %w", sinkAddr, err)
 		}
 		defer stopSink()
 	}
 
 	if err := os.MkdirAll(cfg.ReportDir, 0o755); err != nil {
-		exitErr(fmt.Errorf("failed to create report dir: %w", err))
+		return fmt.Errorf("failed to create report dir: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -135,10 +146,20 @@ func main() {
 
 	timestamp := time.Now().Format("20060102-150405")
 	if err := writeReports(cfg.ReportDir, timestamp, rep); err != nil {
-		exitErr(fmt.Errorf("failed to write reports: %w", err))
+		return fmt.Errorf("failed to write reports: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Load test finished. Reports written to %s\n", cfg.ReportDir)
+	printRunSummary(cfg.ReportDir, rep)
+
+	if runErr != nil {
+		return runErr
+	}
+
+	return nil
+}
+
+func printRunSummary(reportDir string, rep report) {
+	fmt.Fprintf(os.Stdout, "Load test finished. Reports written to %s\n", reportDir)
 	fmt.Fprintf(
 		os.Stdout,
 		"Completed: %d, Failed: %d, Max simultaneous: %d\n",
@@ -160,10 +181,6 @@ func main() {
 		rep.ThroughputTotalMBSec,
 		rep.ThroughputPerConnMBSec,
 	)
-
-	if runErr != nil {
-		exitErr(runErr)
-	}
 }
 
 func parseFlags() (config, error) {
@@ -196,6 +213,127 @@ func parseFlags() (config, error) {
 	}
 
 	return cfg, nil
+}
+
+func normalizeLocalSinkTarget(cfg config) (config, error) {
+	if !cfg.UseLocalSink {
+		return cfg, nil
+	}
+
+	targetAddr, rewritten, err := rewriteLocalSinkTarget(cfg.TargetAddr)
+	if err != nil {
+		return cfg, err
+	}
+	if !rewritten {
+		return cfg, nil
+	}
+
+	cfg.TargetAddr = targetAddr
+	return cfg, nil
+}
+
+func rewriteLocalSinkTarget(targetAddr string) (string, bool, error) {
+	host, _, err := net.SplitHostPort(targetAddr)
+	if err != nil {
+		return "", false, fmt.Errorf("split local sink target address: %w", err)
+	}
+	if !shouldRewriteLocalSinkHost(host) {
+		return targetAddr, false, nil
+	}
+
+	hostIP, err := detectLocalIPv4()
+	if err != nil {
+		return "", false, fmt.Errorf("detect local sink host IP: %w", err)
+	}
+
+	return rewriteLocalSinkTargetWithIP(targetAddr, hostIP)
+}
+
+func rewriteLocalSinkTargetWithIP(targetAddr, hostIP string) (string, bool, error) {
+	host, port, err := net.SplitHostPort(targetAddr)
+	if err != nil {
+		return "", false, fmt.Errorf("split local sink target address: %w", err)
+	}
+	if !shouldRewriteLocalSinkHost(host) {
+		return targetAddr, false, nil
+	}
+
+	return net.JoinHostPort(hostIP, port), true, nil
+}
+
+func shouldRewriteLocalSinkHost(host string) bool {
+	switch host {
+	case "host.docker.internal", "localhost", "127.0.0.1", "0.0.0.0", "::1":
+		return true
+	default:
+		return false
+	}
+}
+
+func detectLocalIPv4() (string, error) {
+	if ip, ok := detectDialLocalIPv4(); ok {
+		return ip, nil
+	}
+
+	if ip, ok := detectInterfaceLocalIPv4(); ok {
+		return ip, nil
+	}
+
+	return "", errors.New("no active non-loopback IPv4 address found")
+}
+
+func detectDialLocalIPv4() (string, bool) {
+	conn, err := net.Dial("udp4", "192.0.2.1:80")
+	if err != nil {
+		return "", false
+	}
+	defer conn.Close()
+
+	localAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return "", false
+	}
+
+	ip := localAddr.IP.To4()
+	if ip == nil || ip.IsLoopback() {
+		return "", false
+	}
+
+	return ip.String(), true
+}
+
+func detectInterfaceLocalIPv4() (string, bool) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", false
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			ip := ipNet.IP.To4()
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+
+			return ip.String(), true
+		}
+	}
+
+	return "", false
 }
 
 func runLoad(cfg config) ([]connectionSample, int64, error) {

--- a/proxy/cmd/loadtest/main_test.go
+++ b/proxy/cmd/loadtest/main_test.go
@@ -132,6 +132,35 @@ func TestSinkListenAddr(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRewriteLocalSinkTarget(t *testing.T) {
+	t.Run("rewrites container host alias", func(t *testing.T) {
+		targetAddr, rewritten, err := rewriteLocalSinkTargetWithIP("host.docker.internal:18080", "127.0.0.1")
+		require.NoError(t, err)
+		require.True(t, rewritten)
+		assert.Equal(t, "127.0.0.1:18080", targetAddr)
+	})
+
+	t.Run("keeps explicit remote host", func(t *testing.T) {
+		targetAddr, rewritten, err := rewriteLocalSinkTargetWithIP("example.com:18080", "127.0.0.1")
+		require.NoError(t, err)
+		require.False(t, rewritten)
+		assert.Equal(t, "example.com:18080", targetAddr)
+	})
+
+	t.Run("rejects invalid target", func(t *testing.T) {
+		_, _, err := rewriteLocalSinkTargetWithIP("bad", "127.0.0.1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "split local sink target address")
+	})
+}
+
+func TestShouldRewriteLocalSinkHost(t *testing.T) {
+	assert.True(t, shouldRewriteLocalSinkHost("host.docker.internal"))
+	assert.True(t, shouldRewriteLocalSinkHost("localhost"))
+	assert.True(t, shouldRewriteLocalSinkHost("127.0.0.1"))
+	assert.False(t, shouldRewriteLocalSinkHost("example.com"))
+}
+
 func TestBuildReport(t *testing.T) {
 	start := time.Now()
 	end := start.Add(10 * time.Second)


### PR DESCRIPTION
## Summary
The built-in SOCKS5 load test could fail with `all connections failed` when `--use-local-sink=true` was used against a proxy running inside Docker and the target was specified as `host.docker.internal:...` (or another loopback-style host).

In that setup the load test started the sink on the host machine, but the SOCKS5 `CONNECT` request still carried a host name such as `host.docker.internal`. The proxy container then had to resolve and reach that name itself. On the reproduced local setup this resolution path was broken, so the proxy returned SOCKS5 reply `0x04` (`Host unreachable`) and every connection failed before any payload transfer started.

## Root Cause
The load test treated the configured target host literally even when the sink was started locally by the same process. That meant the proxy process, not the load test runner, owned DNS resolution for `host.docker.internal` / `localhost` / other loopback-style aliases. When the proxy lived inside Docker, those names were not reliably usable for reaching the host-side sink.

## Fix
The load test now normalizes loopback-style local-sink targets before the SOCKS5 handshake. When `--use-local-sink=true` and the target host is `host.docker.internal`, `localhost`, `127.0.0.1`, `0.0.0.0`, or `::1`, the command resolves the current machine's non-loopback IPv4 address and sends that concrete IP in the SOCKS5 `CONNECT` request.

This keeps the sink reachable for a dockerized proxy without requiring user-specific compose tweaks. The implementation prefers the outbound IPv4 selected by a UDP dial and falls back to scanning active non-loopback interfaces. I also added focused tests for the rewrite logic and documented the behavior in the load test README section.

## Validation
I validated the change locally against a proxy started with Docker Compose.

Checks run:
- `cd proxy && make test`
- `cd proxy && make lint`
- `cd proxy && go run ./cmd/loadtest --proxy-addr=127.0.0.1:54321 --target-addr=host.docker.internal:18080 --use-local-sink=true --concurrency=30 --total-connections=100 --payload-bytes=524288 --username=test1 --password=test1`

The reproduced load test completed successfully after the fix with `Completed: 100, Failed: 0`.
